### PR TITLE
Discord RPC

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "bufferutil": "^4.0.1",
     "csv-parse": "3",
     "deepmerge": "^2.0.1",
+    "discord-rich-presence": "0.0.8",
     "dompurify": "^1.0.4",
     "electron": "2",
     "history": "^4.7.2",

--- a/src/declarations/discord-rich-presence.d.ts
+++ b/src/declarations/discord-rich-presence.d.ts
@@ -1,0 +1,1 @@
+declare module 'discord-rich-presence'

--- a/src/main/Connection.ts
+++ b/src/main/Connection.ts
@@ -172,7 +172,7 @@ export class Connection {
       this.loop = null
     }
     connector.closeWebSocket(code, this.hasError)
-    updateRPC({state: "Ready", details: "Ready"}, true)
+    updateRPC({state: "Ready", details: "Ready", largeImageKey: "net64", largeImageText: `Net64+ ${process.env.VERSION}`}, true)
     if (!emulator) return
     emulator.reset()
   }

--- a/src/main/Connection.ts
+++ b/src/main/Connection.ts
@@ -172,7 +172,7 @@ export class Connection {
       this.loop = null
     }
     connector.closeWebSocket(code, this.hasError)
-    updateRPC({state: "Ready", details: "", smallImageKey: "", smallImageText: "", startTimestamp: "", partySize: null, partyMax: null})
+    updateRPC({state: "Ready", details: "Ready"}, true)
     if (!emulator) return
     emulator.reset()
   }

--- a/src/main/Connection.ts
+++ b/src/main/Connection.ts
@@ -34,36 +34,36 @@ function getGameModeString(gamemodeInteger: number) {
   var retObj: {[k: string]: any} = {};
   switch(gamemodeInteger) {
     case 1:
-      retObj.name = "Regular"
-      retObj.imageName = "regular"
+      retObj.name = 'Regular'
+      retObj.imageName = 'regular'
       break
     case 2:
-      retObj.name = "Third Person Shooter"
-      retObj.imageName = "shooter"
+      retObj.name = 'Third Person Shooter'
+      retObj.imageName = 'shooter'
       break
     case 3:
-      retObj.name = "Interactionless"
-      retObj.imageName = "interactionless"
+      retObj.name = 'Interactionless'
+      retObj.imageName = 'interactionless'
       break
     case 4:
-      retObj.name = "Prop Hunt"
-      retObj.imageName = "prop_hunt"
+      retObj.name = 'Prop Hunt'
+      retObj.imageName = 'prop_hunt'
       break
     case 5:
-      retObj.name = "Boss Rush"
-      retObj.imageName = "boss_rush"
+      retObj.name = 'Boss Rush'
+      retObj.imageName = 'boss_rush'
       break
     case 6:
-      retObj.name = "Tag"
-      retObj.imageName = "tag"
+      retObj.name = 'Tag'
+      retObj.imageName = 'tag'
       break
     case 8:
-      retObj.name = "Wario Ware"
-      retObj.imageName = "wario_ware"
+      retObj.name = 'Wario Ware'
+      retObj.imageName = 'wario_ware'
       break
     default:
-      retObj.name = "None"
-      retObj.imageName = ""
+      retObj.name = 'None'
+      retObj.imageName = ''
       break
   }
   return retObj
@@ -172,7 +172,7 @@ export class Connection {
       this.loop = null
     }
     connector.closeWebSocket(code, this.hasError)
-    updateRPC({state: "Ready", details: "Ready", largeImageKey: "net64", largeImageText: `Net64+ ${process.env.VERSION}`}, true)
+    updateRPC({state: 'Ready', details: 'Ready', largeImageKey: 'net64', largeImageText: `Net64+ ${process.env.VERSION}`}, true)
     if (!emulator) return
     emulator.reset()
   }

--- a/src/main/Connection.ts
+++ b/src/main/Connection.ts
@@ -29,9 +29,8 @@ const MAX_SERVER_PLAYER = 24
  * Helper function to sort gamemode as the DRPC image and gamemode as readable name
  * @param {number} gamemodeInteger - The integer of the gamemode ranging from 1-6, 8
  */
-
-function getGameModeString(gamemodeInteger: number) {
-  var retObj: {[k: string]: any} = {};
+function getGameModeString(gamemodeInteger: number): {[k: string]: string} {
+  var retObj: {[k: string]: string} = {}
   switch(gamemodeInteger) {
     case 1:
       retObj.name = 'Regular'
@@ -280,7 +279,7 @@ export class Connection {
         players,
         passwordRequired: handshake.passwordRequired
       })
-      var gamemodeObj = getGameModeString(handshake.gameMode)
+      const gamemodeObj = getGameModeString(handshake.gameMode)
       updateRPC({
         state: `Playing in ${handshake.name}`,
         details: `Playing in ${gamemodeObj.name} mode`,
@@ -381,7 +380,7 @@ export class Connection {
     if (!gameMode || !gameMode.gameMode) return
     emulator!.setGameMode(gameMode.gameMode)
     connector.setGameMode(gameMode.gameMode)
-    var gamemodeObj = getGameModeString(gameMode.gameMode)
+    const gamemodeObj = getGameModeString(gameMode.gameMode)
     updateRPC({details: `Playing in ${gamemodeObj.name} mode`, smallImageKey: gamemodeObj.imageName, smallImageText: gamemodeObj.name})
     connector.commandMessage(`Gamemode changed to ${gameMode.gameMode}`)
   }

--- a/src/main/Connection.ts
+++ b/src/main/Connection.ts
@@ -30,7 +30,7 @@ const MAX_SERVER_PLAYER = 24
  * @param {number} gamemodeInteger - The integer of the gamemode ranging from 1-6, 8
  */
 function getGameModeString(gamemodeInteger: number): {[k: string]: string} {
-  var retObj: {[k: string]: string} = {}
+  const retObj: {[k: string]: string} = {}
   switch(gamemodeInteger) {
     case 1:
       retObj.name = 'Regular'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,8 +50,9 @@ export const deleteConnection = () => {
   connection = undefined
 }
 export const RPCClient = new RPCClientInstance('550708311582834700')
-export const RPCState = {}
-export function updateRPC(update: Object) {
+export var RPCState = {}
+export function updateRPC(update: Object, clean?: boolean) {
+  if (clean) {RPCState = {}}
   Object.assign(RPCState, update)
   RPCClient.updatePresence(RPCState)
 }
@@ -68,7 +69,7 @@ export function updateRPC(update: Object) {
       }
     })
     connector = new Connector(mainWindow)
-    updateRPC({state: "Ready", largeImageKey: "net64", largeImageText: `Net64+ ${process.env.VERSION}`})
+    updateRPC({state: "Ready", details: "Ready", largeImageKey: "net64", largeImageText: `Net64+ ${process.env.VERSION}`})
     mainWindow.loadURL(path.normalize(`file://${__dirname}/index.html`))
 
     if (process.env.NODE_ENV === 'development') {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2,6 +2,7 @@ import { app, BrowserWindow } from 'electron'
 
 import * as path from 'path'
 import * as fs from 'fs'
+import * as RPCClientInstance from 'discord-rich-presence'
 
 import { Connector } from './Connector'
 import { Emulator } from './Emulator'
@@ -48,7 +49,12 @@ export const deleteConnection = () => {
   if (connection) connection.disconnect()
   connection = undefined
 }
-
+export const RPCClient = new RPCClientInstance('550708311582834700')
+export const RPCState = {}
+export function updateRPC(update: Object) {
+  Object.assign(RPCState, update)
+  RPCClient.updatePresence(RPCState)
+}
 ;(() => {
   const onReady = () => {
     const mainWindow = new BrowserWindow({
@@ -62,7 +68,7 @@ export const deleteConnection = () => {
       }
     })
     connector = new Connector(mainWindow)
-
+    updateRPC({state: "Ready", largeImageKey: "net64", largeImageText: `Net64+ ${process.env.VERSION}`})
     mainWindow.loadURL(path.normalize(`file://${__dirname}/index.html`))
 
     if (process.env.NODE_ENV === 'development') {
@@ -76,6 +82,7 @@ export const deleteConnection = () => {
   app.on('ready', onReady)
 
   app.on('window-all-closed', () => {
+    RPCClient.disconnect()
     app.quit()
   })
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,8 +50,8 @@ export const deleteConnection = () => {
   connection = undefined
 }
 export const RPCClient = new RPCClientInstance('550708311582834700')
-export var RPCState = {}
-export function updateRPC(update: Object, clean?: boolean) {
+export let RPCState = {}
+export function updateRPC(update: Object, clean?: boolean): void {
   if (clean) {RPCState = {}}
   Object.assign(RPCState, update)
   RPCClient.updatePresence(RPCState)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,6 +50,11 @@ export const deleteConnection = () => {
   connection = undefined
 }
 export const RPCClient = new RPCClientInstance('550708311582834700')
+RPCClient.on("error", (err: Error) => {
+  if (process.env.NODE_ENV === 'development') {
+    console.error(err)
+  }
+})
 export let RPCState = {}
 export function updateRPC(update: Object, clean?: boolean): void {
   if (clean) {RPCState = {}}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -69,7 +69,7 @@ export function updateRPC(update: Object, clean?: boolean) {
       }
     })
     connector = new Connector(mainWindow)
-    updateRPC({state: "Ready", details: "Ready", largeImageKey: "net64", largeImageText: `Net64+ ${process.env.VERSION}`})
+    updateRPC({state: 'Ready', details: 'Ready', largeImageKey: 'net64', largeImageText: `Net64+ ${process.env.VERSION}`})
     mainWindow.loadURL(path.normalize(`file://${__dirname}/index.html`))
 
     if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
This is a Discord RPC implementation for Net64+  
When used and connected to a server, it should look like this:

![RPC Demo Image](https://i.imgur.com/NxXBA3b.png)

There may be a lot of warnings thrown though as Promises **aren't** handled.  
And also, if you want, you can send the correct artwork for gamemodes as the ones used are converted from SVG and they may be inaccurate.  
The current artworks used are:

![Assets collection](https://i.imgur.com/eoEU2hu.png)


Send it at SuperNiintendo#3700 and I'll upload them to Discord.  
NOTE: The artworks sent **must** be either in .png, .jpg, or .jpeg,  
**must** be at least 512x512 in size,
**highly should** be a square,
and **highly should** be a transparent image.  
The first 2nd are directly Discord's limitation, the latters are based on how Discord displays the artwork.